### PR TITLE
Fix processor when scope provider in another package

### DIFF
--- a/koru-processor/build.gradle.kts
+++ b/koru-processor/build.gradle.kts
@@ -23,8 +23,14 @@ repositories {
 
 kotlin {
 
-    jvm() //this is only used as kapt (annotation processor, so pure jvm)
-
+    //this is only used as kapt (annotation processor, so pure jvm)
+    jvm {
+        val main by compilations.getting {
+            kotlinOptions {
+                jvmTarget = "1.8"
+            }
+        }
+    }
     sourceSets {
 
         val jvmMain by getting {

--- a/koru-processor/src/jvmMain/kotlin/com/futuremind/koru/processor/Processor.kt
+++ b/koru-processor/src/jvmMain/kotlin/com/futuremind/koru/processor/Processor.kt
@@ -164,7 +164,7 @@ class Processor : AbstractProcessor() {
             originalTypeSpec = typeSpec,
             newTypeName = generatedClassName,
             originalToGeneratedInterface = originalToGeneratedInterface,
-            scopeProviderSpec = obtainScopeProviderSpec(annotation, scopeProviders)
+            scopeProviderMemberName = obtainScopeProviderMemberName(annotation, scopeProviders)
         ).build()
 
         FileSpec.builder(originalTypeName.packageName, generatedClassName)
@@ -188,10 +188,10 @@ class Processor : AbstractProcessor() {
             OriginalToGeneratedInterface(originalName, allGeneratedInterfaces[originalName]!!)
         }
 
-    private fun obtainScopeProviderSpec(
+    private fun obtainScopeProviderMemberName(
         annotation: ToNativeClass,
         scopeProviders: Map<ClassName, PropertySpec>
-    ): PropertySpec? {
+    ): MemberName {
         //this is the dirtiest hack ever but it works :O
         //there probably is some way of doing this via kotlinpoet-metadata
         //https://area-51.blog/2009/02/13/getting-class-values-from-annotations-in-an-annotationprocessor/
@@ -207,7 +207,10 @@ class Processor : AbstractProcessor() {
         ) {
             throw IllegalStateException("$typeMirror can only be used in @ToNativeClass(launchOnScope) if it has been annotated with @ExportedScopeProvider")
         }
-        return scopeProviders[typeMirror?.asTypeName()]
+      return MemberName(
+          packageName = (typeMirror?.asTypeName() as ClassName).packageName,
+          simpleName = checkNotNull(scopeProviders[typeMirror.asTypeName()]).name
+      )
     }
 
     private fun String.nonEmptyOr(or: String) = when (this.isEmpty()) {

--- a/koru-processor/src/jvmMain/kotlin/com/futuremind/koru/processor/Processor.kt
+++ b/koru-processor/src/jvmMain/kotlin/com/futuremind/koru/processor/Processor.kt
@@ -191,7 +191,7 @@ class Processor : AbstractProcessor() {
     private fun obtainScopeProviderMemberName(
         annotation: ToNativeClass,
         scopeProviders: Map<ClassName, PropertySpec>
-    ): MemberName {
+    ): MemberName? {
         //this is the dirtiest hack ever but it works :O
         //there probably is some way of doing this via kotlinpoet-metadata
         //https://area-51.blog/2009/02/13/getting-class-values-from-annotations-in-an-annotationprocessor/
@@ -207,10 +207,12 @@ class Processor : AbstractProcessor() {
         ) {
             throw IllegalStateException("$typeMirror can only be used in @ToNativeClass(launchOnScope) if it has been annotated with @ExportedScopeProvider")
         }
-      return MemberName(
-          packageName = (typeMirror?.asTypeName() as ClassName).packageName,
-          simpleName = checkNotNull(scopeProviders[typeMirror.asTypeName()]).name
-      )
+      return scopeProviders[typeMirror?.asTypeName()]?.let {
+          MemberName(
+              packageName = (typeMirror?.asTypeName() as ClassName).packageName,
+              simpleName = it.name
+          )
+      }
     }
 
     private fun String.nonEmptyOr(or: String) = when (this.isEmpty()) {

--- a/koru-processor/src/jvmMain/kotlin/com/futuremind/koru/processor/WrapperClassBuilder.kt
+++ b/koru-processor/src/jvmMain/kotlin/com/futuremind/koru/processor/WrapperClassBuilder.kt
@@ -10,7 +10,7 @@ class WrapperClassBuilder(
     originalTypeSpec: TypeSpec,
     private val newTypeName: String,
     private val originalToGeneratedInterface: OriginalToGeneratedInterface?,
-    private val scopeProviderSpec: PropertySpec?
+    private val scopeProviderMemberName: MemberName
 ) {
 
     companion object {
@@ -74,14 +74,16 @@ class WrapperClassBuilder(
             }
         }
 
-    private fun FunSpec.Builder.addFunctionBody(originalFunSpec: FunSpec) = when {
+    private fun FunSpec.Builder.addFunctionBody(originalFunSpec: FunSpec): FunSpec.Builder = when {
         this.isSuspend -> this.addStatement(
-            "return %T(${scopeProviderSpec?.name}) { ${originalFunSpec.asInvocation()} }",
-            SuspendWrapper::class
+            "return %T(%M) { ${originalFunSpec.asInvocation()} }",
+            SuspendWrapper::class,
+            scopeProviderMemberName
         )
         originalFunSpec.returnType.isFlow -> this.addStatement(
-            "return %T(${scopeProviderSpec?.name}, ${originalFunSpec.asInvocation()})",
-            FlowWrapper::class
+            "return %T(%M, ${originalFunSpec.asInvocation()})",
+            FlowWrapper::class,
+            scopeProviderMemberName
         )
         else -> this.addStatement("return ${originalFunSpec.asInvocation()}")
     }

--- a/koru-processor/src/jvmMain/kotlin/com/futuremind/koru/processor/WrapperClassBuilder.kt
+++ b/koru-processor/src/jvmMain/kotlin/com/futuremind/koru/processor/WrapperClassBuilder.kt
@@ -76,17 +76,29 @@ class WrapperClassBuilder(
 
     private fun FunSpec.Builder.addFunctionBody(originalFunSpec: FunSpec): FunSpec.Builder = when {
         this.isSuspend -> {
-            this.addStatement(
-                "return %T(%M) { ${originalFunSpec.asInvocation()} }",
-                SuspendWrapper::class,
-                scopeProviderMemberName ?: "null"
+            this.addCode(
+                buildCodeBlock {
+                    add("return %T(", SuspendWrapper::class)
+                    if (scopeProviderMemberName != null) {
+                        add("%M", scopeProviderMemberName)
+                    } else {
+                        add("null")
+                    }
+                    add(") { ${originalFunSpec.asInvocation()} }")
+                }
             )
         }
         originalFunSpec.returnType.isFlow -> {
-            this.addStatement(
-                "return %T(%M, ${originalFunSpec.asInvocation()})",
-                FlowWrapper::class,
-                scopeProviderMemberName ?: "null"
+            this.addCode(
+                buildCodeBlock {
+                    add("return %T(", FlowWrapper::class)
+                    if (scopeProviderMemberName != null) {
+                        add("%M", scopeProviderMemberName)
+                    } else {
+                        add("null")
+                    }
+                    add(", ${originalFunSpec.asInvocation()})")
+                }
             )
         }
         else -> this.addStatement("return ${originalFunSpec.asInvocation()}")

--- a/koru-processor/src/jvmMain/kotlin/com/futuremind/koru/processor/WrapperClassBuilder.kt
+++ b/koru-processor/src/jvmMain/kotlin/com/futuremind/koru/processor/WrapperClassBuilder.kt
@@ -76,32 +76,18 @@ class WrapperClassBuilder(
 
     private fun FunSpec.Builder.addFunctionBody(originalFunSpec: FunSpec): FunSpec.Builder = when {
         this.isSuspend -> {
-            if (scopeProviderMemberName != null) {
-                this.addStatement(
-                    "return %T(%M) { ${originalFunSpec.asInvocation()} }",
-                    SuspendWrapper::class,
-                    scopeProviderMemberName
-                )
-            } else {
-                this.addStatement(
-                    "return %T(null) { ${originalFunSpec.asInvocation()} }",
-                    SuspendWrapper::class
-                )
-            }
+            this.addStatement(
+                "return %T(%M) { ${originalFunSpec.asInvocation()} }",
+                SuspendWrapper::class,
+                scopeProviderMemberName ?: "null"
+            )
         }
         originalFunSpec.returnType.isFlow -> {
-            if (scopeProviderMemberName != null) {
-                this.addStatement(
-                    "return %T(%M, ${originalFunSpec.asInvocation()})",
-                    FlowWrapper::class,
-                    scopeProviderMemberName
-                )
-            } else {
-                this.addStatement(
-                    "return %T(null, ${originalFunSpec.asInvocation()})",
-                    FlowWrapper::class
-                )
-            }
+            this.addStatement(
+                "return %T(%M, ${originalFunSpec.asInvocation()})",
+                FlowWrapper::class,
+                scopeProviderMemberName ?: "null"
+            )
         }
         else -> this.addStatement("return ${originalFunSpec.asInvocation()}")
     }


### PR DESCRIPTION
Thanks for the great library!

If the scope provider is in another package, it couldn't be imported and the build failed.
This was fixed by using KotlinPoet's Members format.
https://square.github.io/kotlinpoet/#m-for-members