### PR TITLE
Changed ScopeProvider to be specifiable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
 ## [0.5.0] - 2021-06-06
+### Changed
+- Inject ScopeProvider as a constructor parameter for more flexibility (#1667 by [Takahiro Menju][takahirom])
 ### Fixed
 - Compatibility with Kotlin compiler plugin 1.5.x

--- a/README.md
+++ b/README.md
@@ -148,11 +148,16 @@ loadUserUseCaseIos.loadUser(username: "some username").subscribe(
 <details>
   <summary>What happens under the hood?</summary>
     
-  Under the hood, a top level property `val exportedScopeProvider_mainScopeProvider = MainScopeProvider()` is created. Then, it is injected into the `SuspendWrapper`s and `FlowWrapper`s as the default scope that `launch`es the coroutines. Remember, that you can always provide custom scope if you need to.
+  Under the hood, a top level property `val exportedScopeProvider_mainScopeProvider = MainScopeProvider()` is created. Then, it is injected into the constructor of the wrapped class and then into `SuspendWrapper`s and `FlowWrapper`s as the default scope that `launch`es the coroutines. Remember, that you can always override with your custom scope if you need to.
   
   ```kotlin
-  fun flow(foo: String) = FlowWrapper(exportedScopeProvider_mainScopeProvider, wrapped.flow(foo))
-  fun suspending(foo: String) = SuspendWrapper(exportedScopeProvider_mainScopeProvider) { wrapped.suspending(foo) }
+    public class LoadUserUseCaseIos(
+      private val wrapped: LoadUserUseCase,
+      private val scopeProvider: ScopeProvider?
+    ) {
+      fun flow(foo: String) = FlowWrapper(scopeProvider, wrapped.flow(foo))
+      fun suspending(foo: String) = SuspendWrapper(scopeProvider) { wrapped.suspending(foo) }
+    }
   ```
 
 </details>
@@ -255,10 +260,10 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 ...
-                implementation("com.futuremind:koru:0.4.0")
+                implementation("com.futuremind:koru:0.5.0")
                 configurations.get("kapt").dependencies.add(
                     org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency(
-                        "com.futuremind", "koru-processor", "0.4.0"
+                        "com.futuremind", "koru-processor", "0.5.0"
                     )
                 )
 

--- a/koru-processor/src/jvmTest/kotlin/com/futuremind/koru/processor/ScopeProviderGenerationTest.kt
+++ b/koru-processor/src/jvmTest/kotlin/com/futuremind/koru/processor/ScopeProviderGenerationTest.kt
@@ -119,8 +119,10 @@ class ScopeProviderGenerationTest {
             .getContentByFilename("ImplicitScopeExample$defaultClassNameSuffix.kt")
 
         generatedScopeProvider shouldContain "public val exportedScopeProvider_mainScopeProvider: MainScopeProvider = MainScopeProvider()"
-        generatedClass shouldContain "FlowWrapper(exportedScopeProvider_mainScopeProvider, wrapped.flow(whatever))"
-        generatedClass shouldContain "SuspendWrapper(exportedScopeProvider_mainScopeProvider) { wrapped.suspending(whatever) }"
+        generatedClass shouldContain "FlowWrapper(scopeProvider,\n" +
+                "      wrapped.flow(whatever))"
+        generatedClass shouldContain "SuspendWrapper(scopeProvider) {\n" +
+                "      wrapped.suspending(whatever) }"
 
     }
 
@@ -176,8 +178,10 @@ class ScopeProviderGenerationTest {
 
     generatedScopeProvider shouldContain "public val exportedScopeProvider_mainScopeProvider: MainScopeProvider = MainScopeProvider()"
     generatedClass shouldContain "import com.futuremind.kmm101.test.scope.exportedScopeProvider_mainScopeProvider"
-    generatedClass shouldContain "FlowWrapper(exportedScopeProvider_mainScopeProvider, wrapped.flow(whatever))"
-    generatedClass shouldContain "SuspendWrapper(exportedScopeProvider_mainScopeProvider) { wrapped.suspending(whatever) }"
+    generatedClass shouldContain "FlowWrapper<Float> = FlowWrapper(scopeProvider,\n" +
+            "      wrapped.flow(whatever))"
+    generatedClass shouldContain "SuspendWrapper(scopeProvider) {\n" +
+            "      wrapped.suspending(whatever) }"
   }
 
     @Test


### PR DESCRIPTION
`○○_mainScopeProvider` is a top-level variable that crashes when touched by another thread. Therefore, if you touch it from a background thread on iOS, it will crash.
On the other hand, I introduced Stately and tried to access the variable when initializing the class.
Please let me know if there is another good way.