### PR TITLE
Keep original class visibility in generated class/interface

### DIFF
--- a/koru-processor/src/jvmMain/kotlin/com/futuremind/koru/processor/WrapperClassBuilder.kt
+++ b/koru-processor/src/jvmMain/kotlin/com/futuremind/koru/processor/WrapperClassBuilder.kt
@@ -97,6 +97,8 @@ class WrapperClassBuilder(
                 .build()
         }
 
+    private val modifiers: Set<KModifier> = originalTypeSpec.modifiers.ifEmpty { setOf(KModifier.PUBLIC) }
+
     /**
      * if we have an interface generated based on class signature, we need to add the override
      * modifier to its methods explicitly
@@ -200,6 +202,7 @@ class WrapperClassBuilder(
 
     fun build(): TypeSpec = TypeSpec
         .classBuilder(newTypeName)
+        .addModifiers(modifiers)
         .addSuperinterfaces(superInterfaces)
         .primaryConstructor(constructorSpec)
         .addFunction(secondaryConstructorSpec)

--- a/koru-processor/src/jvmMain/kotlin/com/futuremind/koru/processor/WrapperClassBuilder.kt
+++ b/koru-processor/src/jvmMain/kotlin/com/futuremind/koru/processor/WrapperClassBuilder.kt
@@ -19,42 +19,48 @@ class WrapperClassBuilder(
         private const val SCOPE_PROVIDER_PROPERTY_NAME = "scopeProvider"
     }
 
-    private val constructorSpec = FunSpec.constructorBuilder()
+    private val constructorSpec = FunSpec
+        .constructorBuilder()
         .addParameter(WRAPPED_PROPERTY_NAME, originalTypeName)
         .addParameter(
             ParameterSpec
-                .builder(SCOPE_PROVIDER_PROPERTY_NAME, ScopeProvider::class.asTypeName()
-                    .copy(nullable = true))
+                .builder(
+                    SCOPE_PROVIDER_PROPERTY_NAME,
+                    ScopeProvider::class.asTypeName().copy(nullable = true)
+                )
                 .build()
         )
         .build()
 
-    private val secondaryConstructorSpec = FunSpec.constructorBuilder()
-            .addParameter(WRAPPED_PROPERTY_NAME, originalTypeName)
-            .callThisConstructor(
-                buildCodeBlock {
-                    add("%N", WRAPPED_PROPERTY_NAME)
-                    add(",")
-                    when (scopeProviderMemberName) {
-                        null -> add("null")
-                        else -> add("%M", scopeProviderMemberName)
-                    }
+    private val secondaryConstructorSpec = FunSpec
+        .constructorBuilder()
+        .addParameter(WRAPPED_PROPERTY_NAME, originalTypeName)
+        .callThisConstructor(
+            buildCodeBlock {
+                add("%N", WRAPPED_PROPERTY_NAME)
+                add(",")
+                when (scopeProviderMemberName) {
+                    null -> add("null")
+                    else -> add("%M", scopeProviderMemberName)
                 }
-            )
-            .build()
+            }
+        )
+        .build()
 
-    private val wrappedClassPropertySpec =
-        PropertySpec.builder(WRAPPED_PROPERTY_NAME, originalTypeName)
-            .initializer(WRAPPED_PROPERTY_NAME)
-            .addModifiers(KModifier.PRIVATE)
-            .build()
+    private val wrappedClassPropertySpec = PropertySpec
+        .builder(WRAPPED_PROPERTY_NAME, originalTypeName)
+        .initializer(WRAPPED_PROPERTY_NAME)
+        .addModifiers(KModifier.PRIVATE)
+        .build()
 
-    private val scopeProviderPropertySpec =
-        PropertySpec.builder(SCOPE_PROVIDER_PROPERTY_NAME, ScopeProvider::class.asTypeName()
-            .copy(nullable = true))
-            .initializer(SCOPE_PROVIDER_PROPERTY_NAME)
-            .addModifiers(KModifier.PRIVATE)
-            .build()
+    private val scopeProviderPropertySpec = PropertySpec
+        .builder(
+            SCOPE_PROVIDER_PROPERTY_NAME,
+            ScopeProvider::class.asTypeName().copy(nullable = true)
+        )
+        .initializer(SCOPE_PROVIDER_PROPERTY_NAME)
+        .addModifiers(KModifier.PRIVATE)
+        .build()
 
 
     private val functions = originalTypeSpec.funSpecs
@@ -97,7 +103,10 @@ class WrapperClassBuilder(
                 .build()
         }
 
-    private val modifiers: Set<KModifier> = originalTypeSpec.modifiers.ifEmpty { setOf(KModifier.PUBLIC) }
+    private val modifiers: Set<KModifier> = originalTypeSpec.modifiers.let {
+        if (it.contains(KModifier.PRIVATE)) throw IllegalStateException("Cannot wrap types with `private` modifier. Consider using internal or public.")
+        it.ifEmpty { setOf(KModifier.PUBLIC) }
+    }
 
     /**
      * if we have an interface generated based on class signature, we need to add the override

--- a/koru-processor/src/jvmMain/kotlin/com/futuremind/koru/processor/WrapperInterfaceBuilder.kt
+++ b/koru-processor/src/jvmMain/kotlin/com/futuremind/koru/processor/WrapperInterfaceBuilder.kt
@@ -39,7 +39,10 @@ class WrapperInterfaceBuilder(
         }
 
 
-    private val modifiers: Set<KModifier> = originalTypeSpec.modifiers.ifEmpty { setOf(KModifier.PUBLIC) }
+    private val modifiers: Set<KModifier> = originalTypeSpec.modifiers.let {
+        if (it.contains(KModifier.PRIVATE)) throw IllegalStateException("Cannot wrap types with `private` modifier. Consider using internal or public.")
+        it.ifEmpty { setOf(KModifier.PUBLIC) }
+    }
 
     fun build(): TypeSpec = TypeSpec
         .interfaceBuilder(newTypeName)

--- a/koru-processor/src/jvmMain/kotlin/com/futuremind/koru/processor/WrapperInterfaceBuilder.kt
+++ b/koru-processor/src/jvmMain/kotlin/com/futuremind/koru/processor/WrapperInterfaceBuilder.kt
@@ -38,8 +38,12 @@ class WrapperInterfaceBuilder(
                 .build()
         }
 
+
+    private val modifiers: Set<KModifier> = originalTypeSpec.modifiers.ifEmpty { setOf(KModifier.PUBLIC) }
+
     fun build(): TypeSpec = TypeSpec
         .interfaceBuilder(newTypeName)
+        .addModifiers(modifiers)
         .addFunctions(functions)
         .addProperties(properties)
         .build()


### PR DESCRIPTION
I have a case where I only want to expose the interface to API consumers and not the class implementing it, hence I wanted the generated class to keep the `internal` visibility.

When the visibility was set to `internal` on a class or interface the generated class omitted the visibility and always set it to `public`.

This PR keep the original modifier and uses `public` as a fallback if none is set.