### PR TITLE
Make compatible with Gradle 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ To use the library in a KMM project, use this config in the `build.gradle.kts`:
 plugins {
     //add ksp and koru compiler plugin
     id("com.google.devtools.ksp") version "1.6.21-1.0.6"
-    id("com.futuremind.koru").version("0.11.1")
+    id("com.futuremind.koru").version("0.13.0")
 }
 
 kotlin {
@@ -256,7 +256,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 // add library dependency
-                implementation("com.futuremind:koru:0.11.1")
+                implementation("com.futuremind:koru:0.13.0")
             }
         }
       
@@ -266,12 +266,6 @@ kotlin {
         
     }
     
-}
-
-koru {
-    // let the compiler plugin know where the generated code should be available
-    // by providing the name of ios source set
-    nativeSourceSetNames = listOf("iosMain")
 }
 ```
 

--- a/koru-compiler-plugin/src/main/kotlin/com/futuremind/koru/gradle/CompilerPlugin.kt
+++ b/koru-compiler-plugin/src/main/kotlin/com/futuremind/koru/gradle/CompilerPlugin.kt
@@ -4,21 +4,14 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.dependencies
-import org.gradle.kotlin.dsl.getByType
-import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
-import java.io.File
 
 
 class CompilerPlugin : Plugin<Project> {
 
     override fun apply(project: Project) = with(project) {
-        val extension: KoruPluginExtension = extensions.create("koru")
         requireKspPluginDependency()
-        enableKspRunForCommonMainSourceSet()
-        makeSureCompilationIsRunAfterKsp()
         afterEvaluate {
-            requireSourceSetsNamesSet(extension.nativeSourceSetNames)
-            addGeneratedFilesToSourceSets(extension.nativeSourceSetNames)
+            enableKspRunForAppleSourceSet()
         }
     }
 
@@ -28,45 +21,13 @@ class CompilerPlugin : Plugin<Project> {
         }
     }
 
-    private fun Project.enableKspRunForCommonMainSourceSet() = dependencies {
-        //todo don't hardcode version
-        add("kspCommonMainMetadata", "com.futuremind:koru-processor:0.12.0")
-    }
-
-    private fun Project.makeSureCompilationIsRunAfterKsp() = tasks
-        .matching {
-            it.name.startsWith("compileKotlinIos")
-                    || it.name.startsWith("compileKotlinMacos")
-                    || it.name.startsWith("compileKotlinWatchos")
-                    || it.name.startsWith("compileKotlinTvos")
-        }
-        .configureEach {
-            dependsOn("kspCommonMainKotlinMetadata")
-        }
-
-    private fun requireSourceSetsNamesSet(nativeSourceSetNames: List<String>) {
-        require(nativeSourceSetNames.isNotEmpty()) {
-            "You need to provide the name of your main native source set in your build.gradle, e.g. koru.nativeSourceSetNames = listOf(\"iosMain\")"
-        }
-    }
-
-    private fun Project.addGeneratedFilesToSourceSets(sourceSetNames: List<String>) {
-        val anyMatch = extensions
-            .getByType<KotlinMultiplatformExtension>().sourceSets
-            .any { sourceSetNames.contains(it.name) }
-        if (!anyMatch) throw IllegalStateException("None of the provided source set names were matched: $sourceSetNames. You need to provide the name of your main native source set in your build.gradle, e.g. koru.nativeSourceSetNames = listOf(\"iosMain\")")
-
-        extensions
-            .getByType<KotlinMultiplatformExtension>().sourceSets
-            .matching { sourceSetNames.contains(it.name) }
-            .configureEach {
-                kotlin.srcDir("${project.buildDir.absolutePath}${File.separator}generated${File.separator}ksp${File.separator}metadata${File.separator}commonMain${File.separator}kotlin")
+    private fun Project.enableKspRunForAppleSourceSet() = dependencies {
+        val kspAppleRegex = "ksp[Ios|Tvos|Macos|Watchos]+(?!.*Test$)".toRegex()
+        configurations
+            .filter { it.name.contains(kspAppleRegex) }
+            .forEach {
+                //todo don't hardcode version
+                add(it.name, "com.futuremind:koru-processor:0.13.0")
             }
     }
 }
-
-open class KoruPluginExtension {
-    var nativeSourceSetNames: List<String> = listOf()
-}
-
-

--- a/koru-processor/src/jvmMain/kotlin/com/futuremind/koru/processor/builders/WrapperClassBuilder.kt
+++ b/koru-processor/src/jvmMain/kotlin/com/futuremind/koru/processor/builders/WrapperClassBuilder.kt
@@ -19,6 +19,7 @@ class WrapperClassBuilder(
     companion object {
         private const val WRAPPED_PROPERTY_NAME = "wrapped"
         private const val SCOPE_PROVIDER_PROPERTY_NAME = "scopeProvider"
+        private val SUSPEND_WRAPPER_TYPE_NAME = SuspendWrapper::class.asTypeName()
     }
 
     private val constructorSpec = FunSpec
@@ -132,7 +133,7 @@ class WrapperClassBuilder(
         originalFunSpec: FunSpec
     ): FunSpec.Builder = addCode(
         buildCodeBlock {
-            add("return %T(", SuspendWrapper::class)
+            add("return %T(", SUSPEND_WRAPPER_TYPE_NAME)
             add(SCOPE_PROVIDER_PROPERTY_NAME)
             add(", ")
             add("%L", freezeWrapper)

--- a/koru-processor/src/jvmMain/kotlin/com/futuremind/koru/processor/builders/WrapperClassBuilder.kt
+++ b/koru-processor/src/jvmMain/kotlin/com/futuremind/koru/processor/builders/WrapperClassBuilder.kt
@@ -20,6 +20,7 @@ class WrapperClassBuilder(
         private const val WRAPPED_PROPERTY_NAME = "wrapped"
         private const val SCOPE_PROVIDER_PROPERTY_NAME = "scopeProvider"
         private val SUSPEND_WRAPPER_TYPE_NAME = SuspendWrapper::class.asTypeName()
+        private val FLOW_WRAPPER_TYPE_NAME = FlowWrapper::class.asTypeName()
     }
 
     private val constructorSpec = FunSpec
@@ -150,7 +151,7 @@ class WrapperClassBuilder(
     )
 
     private fun flowWrapperFunctionBody(callOriginal: String) = buildCodeBlock {
-        add("return %T(", FlowWrapper::class)
+        add("return %T(", FLOW_WRAPPER_TYPE_NAME)
         add(SCOPE_PROVIDER_PROPERTY_NAME)
         add(", %L", freezeWrapper)
         add(", ${callOriginal})")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,7 +2,7 @@ rootProject.name = "Koru"
 
 gradle.allprojects {
     group = "com.futuremind"
-    version = "0.12.0"
+    version = "0.13.0"
 }
 
 includeBuild("publish-plugin")


### PR DESCRIPTION
The source code generated by `kspCommonMainMetadata` from `/build/generated/ksp/metadata/commonMain/kotlin` was being set as the `srcDir` for the `iosMain` source set. 
However, this setup resulted in errors when using Gradle 8. 
As a solution, I attempted to specify options like `kspIosArm64`, but this led to a `TypeMirror` error, as documented in https://github.com/square/kotlinpoet/issues/1273.

In order to make koru compatible with Gradle 8, the following changes were made:

- Replaced  `Xxx::class` with `Xxx::class.asTypeName()` [cba6d5a](https://github.com/FutureMind/koru/pull/58/commits/cba6d5a2a1bcf8e254c9701aed9dd823298b6135) [21cad65](https://github.com/FutureMind/koru/pull/58/commits/21cad6519a34023c6e60f8b7551b04cec2024f54)
- Stopped using `kspCommonMainMetadata` with the `CompilerPlugin` and instead retrieved Apple-related configurations from the configurations and set them accordingly. [7a05ff7](https://github.com/FutureMind/koru/pull/58/commits/7a05ff71fd492d321327f0b72bcf98c64205bbb4)